### PR TITLE
fixup: get_next_version()

### DIFF
--- a/dmtools/io.py
+++ b/dmtools/io.py
@@ -150,8 +150,9 @@ def get_next_version(path: str) -> str:
     Returns:
         str: String file path with version number.
     """
-    filenames = os.scandir('.')
-    r = re.compile(f"{re.escape(path)}_([0-9]+).(png|pgm|pbm|ppm)")
+    filenames = os.scandir(max(os.path.dirname(path), '.'))
+    basename = os.path.basename(path)
+    r = re.compile(f"{re.escape(basename)}_([0-9]+).(png|pgm|pbm|ppm)")
     prev = (int(m[1]) for m in (r.match(f.name) for f in filenames) if m)
     i = 1 + max(prev, default=0)
     return f"{path}_{i:04}"

--- a/dmtools/io.py
+++ b/dmtools/io.py
@@ -150,11 +150,10 @@ def get_next_version(path: str) -> str:
     Returns:
         str: String file path with version number.
     """
-    filenames = next(os.walk('.'), (None, None, []))[2]
-    r = re.compile(f"{path}_[0-9]*.(png|pgm|pbm|ppm)")
-    prev = list(filter(r.match, filenames))
-    prev = [int(f.split('_')[-1].split('.')[0]) for f in prev]
-    i = 1 if len(prev) == 0 else max(prev) + 1
+    filenames = os.scandir('.')
+    r = re.compile(f"{re.escape(path)}_([0-9]+).(png|pgm|pbm|ppm)")
+    prev = (int(m[1]) for m in (r.match(f.name) for f in filenames) if m)
+    i = 1 + max(prev, default=0)
     return f"{path}_{i:04}"
 
 

--- a/dmtools/tests/test_io.py
+++ b/dmtools/tests/test_io.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import shutil
 import pytest
 import numpy as np
 from imageio import imread
@@ -27,6 +28,15 @@ def test_get_next_version():
 
     for i in range(1,10):
         os.remove(f"white_pixel_{i:04}.ppm")
+
+    # test directory prefix
+    dir_name = "dir_for_version_testing"
+    os.makedirs(dir_name, exist_ok=True)
+    for i in range(1,10):
+        expected = f"{dir_name}/white_pixel_{i:04}"
+        assert expected == get_next_version(f"{dir_name}/white_pixel")
+        write_png(image, f"{dir_name}/white_pixel", versioning=True)
+    shutil.rmtree(dir_name)
 
 
 @pytest.mark.parametrize("name",[


### PR DESCRIPTION
Functional changes:

- Escape path in case it has regex operators
- Enforce a version # of >1 digits

Code golfing:

- Use scandir() instead of os.walk()
- Use regex to capture version # while filtering
- Use default in max() instead of a conditional

Queries still:

- Does this work when path has a directory prefix?
- Is this os-neutral, e.g. should use os.path.splitext() instead of
  regex to remove extension?