### PR TITLE
Image Quantization

### DIFF
--- a/dmtools/io.py
+++ b/dmtools/io.py
@@ -124,6 +124,8 @@ def _continuous(image: np.ndarray, k: int) -> np.ndarray:
     Returns:
         np.ndarray: Continuous image with values in [0,1].
     """
+    # TODO: Consider changing to
+    # (image / (k+1)) + (1 / (2 * (k+1)))
     return image / k
 
 
@@ -137,7 +139,8 @@ def _discretize(image: np.ndarray, k: int) -> np.ndarray:
     Returns:
         np.ndarray: Discrete image with values in [0,k].
     """
-    # TODO: Is this the right way to discretize?
+    # TODO: Consider changing to
+    # np.ceil(image * (k+1)).astype(int) + 1
     return np.ceil(k*image - 0.5).astype(int)
 
 


### PR DESCRIPTION
The current implementation of _continuous, $x/k$ maps 0 to 0 and k to 1 which
feels desirable. However, I beleive _discretize should be the inverse of
_continuous which results in the current implementation of _discretize being
$ceil(x*k - 0.5)$ which has "bins" of differing widths at the extremes (half
the width of the internal bins). This does not feel right. The TODO notes
describe a counter-proposal in which _discretize maps to constant-width bins
but the inverse means that _continuous no longer maps 0 and k to 0 and 1
respectivley. This also feels wrong.